### PR TITLE
Change propsys replacement reference

### DIFF
--- a/cpp/ICWFGM_GridEngine.cpp
+++ b/cpp/ICWFGM_GridEngine.cpp
@@ -30,7 +30,7 @@
 #include <float.h>
 #include <stdio.h>
 
-#include "propsysreplacement.cpp"
+#include "propsysreplacement.h"
 
 #ifdef DEBUG
 #include <assert.h>


### PR DESCRIPTION
The propsys replacement methods were added to LowLevel, don't need to include the cpp file directly here. Just reference the header file.