### PR TITLE
Invalid boost reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,10 @@ find_package(Boost COMPONENTS atomic system iostreams REQUIRED PATHS ${BOOST_LIB
 else ()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
 
-find_package(Boost COMPONENTS system iostreams REQUIRED PATHS ${BOOST_LIBRARY_DIR})
+set(Boost_LIBRARIES
+    -L${BOOST_LIBRARY_DIR}/lib
+    -lboost_system
+    -lboost_iostreams)
 endif (MSVC)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_NO_MFC")


### PR DESCRIPTION
CMake was forcing system paths to be searched for boost on Ubuntu instead of using the hint path. Manually add the reference to boost instead to bypass this issue.