### PR TITLE
Move the export driver list to paths/strings

### DIFF
--- a/cpp/CWFGM_Target.Serialize.cpp
+++ b/cpp/CWFGM_Target.Serialize.cpp
@@ -41,24 +41,12 @@ using namespace ResultCodes;
 
 
 
-HRESULT CCWFGM_Target::ImportPointSet(const std::string& file_path, const std::vector<std::string>* permissible_drivers) {
-	if (!file_path.length())						return E_POINTER;
+HRESULT CCWFGM_Target::ImportPointSet(const std::filesystem::path& file_path, const std::vector<std::string_view> &permissible_drivers) {
+	if (file_path.empty())						return E_POINTER;
 
 	SEM_BOOL engaged;
 	CRWThreadSemaphoreEngage engage(m_lock, SEM_TRUE, &engaged, 1000000LL);
 	if (!engaged)								return ERROR_SCENARIO_SIMULATION_RUNNING;
-
-	const char** pd;
-	if (permissible_drivers && permissible_drivers->size() > 0) {
-		if (pd = (const char**)malloc(sizeof(char*) * (size_t)(permissible_drivers->size() + 1))) {
-			std::uint32_t i;
-			for (i = 0; i < (std::uint32_t)permissible_drivers->size(); i++) {
-				pd[i] = strdup((*permissible_drivers)[i].c_str());
-			}
-			pd[i] = nullptr;
-		}
-	}
-	else pd = nullptr;
 
 	boost::intrusive_ptr<ICWFGM_GridEngine> gridEngine;
 	HRESULT hr;
@@ -70,18 +58,12 @@ HRESULT CCWFGM_Target::ImportPointSet(const std::string& file_path, const std::v
 	double gridResolution;
 
 	if ((gridEngine = m_gridEngine) != nullptr) {
-		if (FAILED(hr = gridEngine->GetDimensions(0, &xdim, &ydim)))								{ if (pd) { std::uint32_t i = 0; while (pd[i]) free((APTR)pd[i++]); free(pd); } return hr; }
+		if (FAILED(hr = gridEngine->GetDimensions(0, &xdim, &ydim)))								{ return hr; }
 
 		PolymorphicAttribute var;
-		if (FAILED(hr = gridEngine->GetAttribute(0, CWFGM_GRID_ATTRIBUTE_PLOTRESOLUTION, &var)))	{ if (pd) { std::uint32_t i = 0; while (pd[i]) free((APTR)pd[i++]); free(pd); } return hr; } VariantToDouble_(var, &gridResolution);
+		if (FAILED(hr = gridEngine->GetAttribute(0, CWFGM_GRID_ATTRIBUTE_PLOTRESOLUTION, &var)))	{ return hr; } VariantToDouble_(var, &gridResolution);
 
 		if (FAILED(hr = gridEngine->GetAttribute(0, CWFGM_GRID_ATTRIBUTE_SPATIALREFERENCE, &var))) {
-			if (pd) {
-				std::uint32_t i = 0;
-				while (pd[i])
-					free((APTR)pd[i++]);
-				free(pd);
-			}
 			return hr;
 		}
 		std::string projection;
@@ -90,12 +72,6 @@ HRESULT CCWFGM_Target::ImportPointSet(const std::string& file_path, const std::v
 		try { projection = std::get<std::string>(var); }
 		catch (std::bad_variant_access&) { 
 			weak_assert(false);
-			if (pd) {
-				std::uint32_t i = 0;
-				while (pd[i])
-					free((APTR)pd[i++]);
-				free(pd);
-			} 
 			return ERROR_PROJECTION_UNKNOWN;
 		}
 
@@ -103,14 +79,13 @@ HRESULT CCWFGM_Target::ImportPointSet(const std::string& file_path, const std::v
 	}
 	else {
 		weak_assert(false);
-		if (pd) { std::uint32_t i = 0; while (pd[i]) free((APTR)pd[i++]); free(pd); }
 		return ERROR_VECTOR_UNINITIALIZED;
 	}
 
 	XY_PolyLLSetAttributes set;
 	set.SetCacheScale(gridResolution);
 
-	if (SUCCEEDED(hr = set.ImportPoly(pd, file_path.c_str(), oSourceSRS, nullptr, nullptr, nullptr, true))) {
+	if (SUCCEEDED(hr = set.ImportPoly(permissible_drivers, file_path, oSourceSRS, nullptr, nullptr, nullptr, true))) {
 		XY_PolyLLAttributes* pa = set.LH_Head();
 		while (pa->LN_Succ()) {
 			if (!pa->IsMultiPoint())		// targets must be only (multi)point data
@@ -142,7 +117,6 @@ HRESULT CCWFGM_Target::ImportPointSet(const std::string& file_path, const std::v
 	}
 	if (oSourceSRS)
 		OSRDestroySpatialReference(oSourceSRS);
-	if (pd) { std::uint32_t i = 0; while (pd[i]) free((APTR)pd[i++]); free(pd); } 
 	return hr;
 }
 
@@ -201,7 +175,8 @@ HRESULT CCWFGM_Target::ImportPointSetWFS(const std::string& url, const std::stri
 	layers.push_back(csLayer);
 	XY_PolyLLSet pset;
 	std::string URI = prepareUri(csURL);
-	if (SUCCEEDED(hr = set.ImportPoly(NULL, URI.c_str(), oSourceSRS, NULL, &layers))) {
+	const std::vector<std::string_view> drivers;
+	if (SUCCEEDED(hr = set.ImportPoly(drivers, URI.c_str(), oSourceSRS, NULL, &layers))) {
 		RefNode<XY_PolyType>* node;
 		while ((node = m_targets.RemHead()) != NULL) {
 			delete node->LN_Ptr();
@@ -229,8 +204,8 @@ HRESULT CCWFGM_Target::ImportPointSetWFS(const std::string& url, const std::stri
 }
 
 
-HRESULT CCWFGM_Target::ExportPointSet(const std::string& driver_name, const std::string& bprojection, const std::string& file_path) {
-	if ((!driver_name.length()) || (!file_path.length()))				return E_INVALIDARG;
+HRESULT CCWFGM_Target::ExportPointSet(std::string_view driver_name, const std::string& bprojection, const std::filesystem::path& file_path) {
+	if ((!driver_name.length()) || (file_path.empty()))				return E_INVALIDARG;
 
 	if (!m_targets.GetCount())
 		return E_FAIL;
@@ -273,7 +248,7 @@ HRESULT CCWFGM_Target::ExportPointSet(const std::string& driver_name, const std:
 	}
 
 	set.SetCacheScale(gridResolution);
-	hr = set.ExportPoly(driver_name.c_str(), bprojection.c_str(), oSourceSRS, oTargetSRS);
+	hr = set.ExportPoly(driver_name, file_path, oSourceSRS, oTargetSRS);
 	if (oSourceSRS)
 		OSRDestroySpatialReference(oSourceSRS);
 	if (oTargetSRS)

--- a/include/CWFGM_Asset.h
+++ b/include/CWFGM_Asset.h
@@ -99,7 +99,7 @@ public:
 		\retval	ERROR_HANDLE_DISK_FULL	Disk full.
 		\retval	ERROR_FILE_EXISTS	File already exists.
 	*/
-	virtual NO_THROW HRESULT ImportPolylines(const std::string & file_path, const std::vector<std::string>* permissible_drivers);
+	virtual NO_THROW HRESULT ImportPolylines(const std::filesystem::path & file_path, const std::vector<std::string_view>& permissible_drivers);
 	virtual NO_THROW HRESULT ImportPolylinesWFS(const std::string& url, const std::string& layer, const std::string& username, const std::string& password);
 	/**
 		This method exports polylines / polygons to the specified file.  The projection file is optionally created, and will be the grid's projection.  Driver names are defined by GDAL/OGR, plus "ARCInfo Generate".
@@ -114,7 +114,7 @@ public:
 		\retval	ERROR_SCENARIO_SIMULATION_RUNNING	Unable to continue due to running simulation.
 		\retval ERROR_FIREBREAK_NOT_FOUND	Unable to find firebreak.	
 	*/
-	virtual NO_THROW HRESULT ExportPolylines(const std::string& driver_name, const std::string& projection, const std::string& file_path);
+	virtual NO_THROW HRESULT ExportPolylines(std::string_view driver_name, const std::string& projection, const std::filesystem::path& file_path);
 	virtual NO_THROW HRESULT ExportPolylinesWFS(const std::string& url, const std::string& layer, const std::string& username, const std::string& password);
 	/**
 		This method adds a polyline / polygon defining an area to apply the vector filter.  A vector filter can contain many polylines and/or polygons, and polygons can be overlapping.

--- a/include/CWFGM_PolyReplaceGridFilter.h
+++ b/include/CWFGM_PolyReplaceGridFilter.h
@@ -120,7 +120,7 @@ public:
 		\retval	ERROR_HANDLE_DISK_FULL Disk full
 		\retval	ERROR_FILE_EXISTS	File already exists.
 	*/
-	virtual NO_THROW HRESULT ImportPolygons(const std::string & file_path, const std::vector<std::string> *permissible_drivers);
+	virtual NO_THROW HRESULT ImportPolygons(const std::filesystem::path & file_path, const std::vector<std::string_view> &permissible_drivers);
 	/**
 		This method imports polygons from the specified WFS, looking in the identified layer.  Imported data is automatically reprojected into the grid projection during import.
 		\param	url		Identifies the WFS provider.
@@ -151,7 +151,7 @@ public:
 		\retval	S_FALSE	If asking for values where the appropriate array has not been initialized.
 		\retval	E_INVALIDARG	Invalid arguments.
 	*/
-	virtual NO_THROW HRESULT ExportPolygons(const std::string & driver_name, const std::string & projection, const std::string & file_path);
+	virtual NO_THROW HRESULT ExportPolygons(std::string_view driver_name, const std::string & projection, const std::filesystem::path & file_path);
 	/**
 		This method exports polygons to the specified WFS, to the identified layer.  Exported data is in the grid's projection.
 		\param	url		Identifies the WFS provider.

--- a/include/CWFGM_Target.h
+++ b/include/CWFGM_Target.h
@@ -80,9 +80,9 @@ public:
 		\retval ERROR_SEVERITY_WARNING	Severity error warning
 	*/
 	virtual NO_THROW HRESULT Clone(boost::intrusive_ptr<ICWFGM_CommonBase>* newObject) const override;
-	virtual NO_THROW HRESULT ImportPointSet(const std::string& file_path, const std::vector<std::string>* permissible_drivers);
+	virtual NO_THROW HRESULT ImportPointSet(const std::filesystem::path& file_path, const std::vector<std::string_view>& permissible_drivers);
 	virtual NO_THROW HRESULT ImportPointSetWFS(const std::string& url, const std::string& layer, const std::string& username, const std::string& password);
-	virtual NO_THROW HRESULT ExportPointSet(const std::string& driver_name, const std::string& projection, const std::string& file_path);
+	virtual NO_THROW HRESULT ExportPointSet(std::string_view driver_name, const std::string& projection, const std::filesystem::path& file_path);
 	virtual NO_THROW HRESULT ExportPointSetWFS(const std::string& url, const std::string& layer, const std::string& username, const std::string& password);
 	virtual NO_THROW HRESULT AddPointSet(const XY_PolyConst& xy_pairs, std::uint32_t* index);
 	virtual NO_THROW HRESULT SetPointSet(std::uint32_t index, const XY_PolyConst& xy_pairs);

--- a/include/CWFGM_VectorFilter.h
+++ b/include/CWFGM_VectorFilter.h
@@ -87,7 +87,7 @@ public:
 		\retval	ERROR_HANDLE_DISK_FULL	Disk full.
 		\retval	ERROR_FILE_EXISTS	File already exists.
 	*/
-	virtual NO_THROW HRESULT ImportPolylines(const std::string & file_path, const std::vector<std::string> *permissible_drivers);
+	virtual NO_THROW HRESULT ImportPolylines(const std::filesystem::path & file_path, const std::vector<std::string_view> &permissible_drivers);
 	/**
 		This method imports polylines from the specified WFS, looking in the identified layer.  Imported data is automatically reprojected into the grid projection during import.
 		\param	url		Identifies the WFS provider.
@@ -116,7 +116,7 @@ public:
 		\retval	ERROR_SCENARIO_SIMULATION_RUNNING	Unable to continue due to running simulation.
 		\retval ERROR_FIREBREAK_NOT_FOUND	Unable to find firebreak.	
 	*/
-	virtual NO_THROW HRESULT ExportPolylines(const std::string & driver_name, const std::string & projection, const std::string & file_path);
+	virtual NO_THROW HRESULT ExportPolylines(std::string_view driver_name, const std::string & projection, const std::filesystem::path & file_path);
 	/**
 		This method exports polylines to the specified WFS, to the identified layer.  Exported data is in the grid's projection.
 		\param	url		Identifies the WFS provider.


### PR DESCRIPTION
The list used to be a raw array that relied on having a null at the end, change to a std::vector.